### PR TITLE
fix(ios): resolve when services are set

### DIFF
--- a/ios/BleDidcomm.swift
+++ b/ios/BleDidcomm.swift
@@ -66,6 +66,8 @@ class BleDidcomm: React.RCTEventEmitter {
     centralManager.setService(
       serviceUUID: serviceUUID, writeCharacteristicUUID: writeCharacteristicUUID,
       indicationCharacteristicUUID: indicationCharacteristicUUID)
+
+    resolve(nil)
   }
 
   @objc func startCentral(

--- a/ios/CentralManager.swift
+++ b/ios/CentralManager.swift
@@ -38,11 +38,7 @@ class CentralManager: NSObject {
 
   func shutdownCentral() {
     if let cp = self.connectedPeripheral {
-      do {
-        try self.centralManager.cancelPeripheralConnection(cp)
-      } catch {
-        // We don't care and proceed
-      }
+      self.centralManager.cancelPeripheralConnection(cp)
     }
     if (self.centralManager.isScanning) {
       self.stopScan()

--- a/ios/PeripheralManager.swift
+++ b/ios/PeripheralManager.swift
@@ -28,7 +28,7 @@ class PeripheralManager: NSObject {
     self.peripheralManager = CBPeripheralManager(
       delegate: self,
       queue: nil,
-      options: [CBPeripheralManagerOptionShowPowerAlertKey: true]
+      options: [CBPeripheralManagerOptionShowPowerAlertKey: false]
     )
 
     while !isPoweredOn { Thread.sleep(forTimeInterval: 0.05) }

--- a/ios/PeripheralManager.swift
+++ b/ios/PeripheralManager.swift
@@ -58,7 +58,9 @@ class PeripheralManager: NSObject {
     self.indicationCharacteristic = CBMutableCharacteristic(
       type: CBUUID(string: indicationCharacteristicUUID), properties: [.indicate], value: nil,
       permissions: [.writeable])
-    guard let wc = self.writeCharacteristic, let ic = self.indicationCharacteristic,
+    guard
+      let wc = self.writeCharacteristic,
+      let ic = self.indicationCharacteristic,
       let s = self.service
     else {
       throw PeripheralManagerError.NotConnectedToCentral
@@ -76,11 +78,11 @@ class PeripheralManager: NSObject {
   }
 
   func stopAdvertising() throws {
-    guard let service = self.service else {
+    guard self.service != nil else {
       throw PeripheralManagerError.NoDefinedService
     }
     self.peripheralManager.stopAdvertising()
-  } 
+  }
 
   func indicate(message: Data) throws {
     guard let connectedCentral = connectedCentral else {


### PR DESCRIPTION
- Also sets the power key to false which hides a prompt. This would come up when the user starts scanning and is irrelevant for our flow.